### PR TITLE
fix: Fix failing python test

### DIFF
--- a/python/tests/test_datafusion.py
+++ b/python/tests/test_datafusion.py
@@ -1,14 +1,16 @@
-import pytest
+from pathlib import Path
+
 import zarr_datafusion_search
 from datafusion import SessionContext
 
+ROOT_DIR = Path(__file__).parent.parent.parent
 
-@pytest.mark.skip
+
 def test_zarr_scan():
     ctx = SessionContext()
 
-    zarr_path = "../../data/zarr_store.zarr"
-    zarr_table = zarr_datafusion_search.ZarrTable(zarr_path)
+    zarr_path = ROOT_DIR / "data" / "zarr_store.zarr"
+    zarr_table = zarr_datafusion_search.ZarrTable(str(zarr_path))
 
     ctx.register_table_provider("zarr_data", zarr_table)
 


### PR DESCRIPTION
### Change list

- This test was failing when run from CI because the working directory was different than what it was when I ran it manually. Being consistent about `ROOT_DIR` ensures that this test passes on CI as well