### PR TITLE
fix: dynamically load correct array types given inferred schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2406,9 +2406,9 @@ dependencies = [
 
 [[package]]
 name = "geoarrow-array"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36490f9fbab061752290ac5ebce2bc9bab82ea6fdfcfc9ac3d030d44a98a1a7d"
+checksum = "7d1884b17253d8572e88833c282fcbb442365e4ae5f9052ced2831608253436c"
 dependencies = [
  "arrow-array",
  "arrow-buffer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ arrow-schema = "56.2.0"
 async-trait = "0.1.89"
 datafusion = "50.2"
 futures = "0.3.31"
-geoarrow-array = "0.6.1"
 geoarrow-schema = "0.6.1"
 icechunk = "0.3.13"
 object_store = "0.12.4"
@@ -24,4 +23,5 @@ zarrs_object_store = "0.5.0"
 zarrs_storage = { version = "0.4.0", features = ["async"] }
 
 [dev-dependencies]
+geoarrow-array = "0.6.1"
 tokio = { version = "1.48", features = ["macros", "rt-multi-thread"] }

--- a/src/table_provider.rs
+++ b/src/table_provider.rs
@@ -64,7 +64,6 @@ impl ZarrTableProvider {
     ) -> ZarrDataFusionResult<Self> {
         let zarr_backend = IcechunkBackend::new(icechunk_session, handle);
         let schema = zarr_backend.infer_group_schema(group_path.into()).await?;
-        // dbg!(schema.as_ref());
         Ok(Self {
             schema,
             zarr_backend: zarr_backend.into(),
@@ -257,7 +256,7 @@ impl ZarrBackend {
         // loading the physical data, and the metadata is already held in the schema.
 
         // TODO: refactor so this can be stored in the ZarrBackend
-        let group = "/meta/";
+        let group = "/meta";
         let name = field.name();
         let path = format!("{group}/{name}");
 


### PR DESCRIPTION
In https://github.com/developmentseed/zarr-datafusion-search/pull/19 and https://github.com/developmentseed/zarr-datafusion-search/pull/21 we implemented Arrow schema inference based on the Zarr array types.

But the actual _loading_ of the data inside the DataFusion exec was still hard-coded.

This fixes this so that the DataFusion executor is able to load data in any schema inferred from the Zarr data.

Closes https://github.com/developmentseed/zarr-datafusion-search/issues/12